### PR TITLE
dubbo-proxy throws npe while invoking no  arguments method

### DIFF
--- a/src/main/java/org/apache/dubbo/proxy/worker/RequestWorker.java
+++ b/src/main/java/org/apache/dubbo/proxy/worker/RequestWorker.java
@@ -1,6 +1,7 @@
 package org.apache.dubbo.proxy.worker;
 
 import com.alibaba.fastjson.JSON;
+
 import org.apache.dubbo.proxy.dao.ServiceDefinition;
 import org.apache.dubbo.proxy.dao.ServiceMapping;
 import org.apache.dubbo.proxy.metadata.MetadataCollector;
@@ -33,7 +34,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 
-public class RequestWorker implements Runnable{
+public class RequestWorker implements Runnable {
 
     private ServiceDefinition serviceDefinition;
     private ChannelHandlerContext ctx;
@@ -60,7 +61,7 @@ public class RequestWorker implements Runnable{
         String interfaze = Tool.getInterface(serviceID);
         String group = Tool.getGroup(serviceID);
         String version = Tool.getVersion(serviceID);
-        if (serviceDefinition.getParamTypes() == null) {
+        if (serviceDefinition.getParamTypes() == null && serviceDefinition.getParamValues() != null) {
             String[] types = getTypesFromMetadata(serviceDefinition.getApplication(), interfaze, group, version,
                     serviceDefinition.getMethodName(), serviceDefinition.getParamValues().length);
             serviceDefinition.setParamTypes(types);
@@ -103,7 +104,7 @@ public class RequestWorker implements Runnable{
             Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode(cookieString);
             if (!cookies.isEmpty()) {
                 // Reset the cookies if necessary.
-                for (Cookie cookie: cookies) {
+                for (Cookie cookie : cookies) {
                     response.headers().add(HttpHeaderNames.SET_COOKIE, ServerCookieEncoder.STRICT.encode(cookie));
                 }
             }
@@ -119,7 +120,7 @@ public class RequestWorker implements Runnable{
         MetadataIdentifier identifier = new MetadataIdentifier(interfaze, version, group, Constants.PROVIDER_SIDE, application);
         String metadata = metadataCollector.getProviderMetaData(identifier);
         FullServiceDefinition serviceDefinition = JSON.parseObject(metadata, FullServiceDefinition.class);
-        List<MethodDefinition> methods  = serviceDefinition.getMethods();
+        List<MethodDefinition> methods = serviceDefinition.getMethods();
         if (methods != null) {
             for (MethodDefinition m : methods) {
                 if (Tool.sameMethod(m, methodName, paramLen)) {


### PR DESCRIPTION
maybe we hava a method without args
so it makes a npe like below
```
Exception in thread "Dubbo-proxy-request-worker-pool-thread-3" java.lang.NullPointerException
        at org.apache.dubbo.proxy.worker.RequestWorker.run(RequestWorker.java:65)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:748)
```