### PR TITLE
upgrade dubbo version to 2.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<slf4j.version>1.7.26</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
 		<curator.version>2.12.0</curator.version>
-		<dubbo.version>2.7.3</dubbo.version>
+		<dubbo.version>2.7.7</dubbo.version>
 	</properties>
 
 	<dependencyManagement>

--- a/src/main/java/org/apache/dubbo/proxy/metadata/MetadataCollector.java
+++ b/src/main/java/org/apache/dubbo/proxy/metadata/MetadataCollector.java
@@ -2,7 +2,7 @@ package org.apache.dubbo.proxy.metadata;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.SPI;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 
 @SPI("zookeeper")
 public interface MetadataCollector {

--- a/src/main/java/org/apache/dubbo/proxy/metadata/impl/ZookeeperMetadataCollector.java
+++ b/src/main/java/org/apache/dubbo/proxy/metadata/impl/ZookeeperMetadataCollector.java
@@ -1,5 +1,6 @@
 package org.apache.dubbo.proxy.metadata.impl;
 
+import org.apache.dubbo.metadata.report.identifier.KeyTypeEnum;
 import org.apache.dubbo.proxy.metadata.MetadataCollector;
 import org.apache.dubbo.proxy.utils.Constants;
 import org.apache.curator.framework.CuratorFramework;
@@ -8,7 +9,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 
 public class ZookeeperMetadataCollector implements MetadataCollector {
 
@@ -47,7 +48,7 @@ public class ZookeeperMetadataCollector implements MetadataCollector {
     }
 
     private String getNodePath(MetadataIdentifier metadataIdentifier) {
-        return toRootDir() + metadataIdentifier.getUniqueKey(MetadataIdentifier.KeyTypeEnum.PATH) +
+        return toRootDir() + metadataIdentifier.getUniqueKey(KeyTypeEnum.PATH) +
                 Constants.PATH_SEPARATOR + METADATA_NODE_NAME;
     }
 

--- a/src/main/java/org/apache/dubbo/proxy/service/GenericInvoke.java
+++ b/src/main/java/org/apache/dubbo/proxy/service/GenericInvoke.java
@@ -1,9 +1,9 @@
 package org.apache.dubbo.proxy.service;
 
-import org.apache.dubbo.proxy.utils.ResultCode;
 import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ReferenceConfig;
 import org.apache.dubbo.config.RegistryConfig;
+import org.apache.dubbo.proxy.utils.ResultCode;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.service.GenericService;
@@ -47,9 +47,8 @@ public class GenericInvoke {
 
         try {
             GenericService svc = reference.get();
-            logger.info("dubbo generic invoke, service is {}, method is {} , paramTypes is {} , paramObjs is {} , svc" +
-                            " is {}.", interfaceName
-                    , methodName,paramTypes,paramObjs,svc);
+            logger.info("dubbo generic invoke, service is {}, method is {} , paramTypes is {} , paramObjs is {} , svc is {}.",
+                    interfaceName, methodName, paramTypes, paramObjs, svc);
             return svc.$invoke(methodName, paramTypes, paramObjs);
         } catch (Exception e) {
             logger.error("Generic invoke failed",e);
@@ -74,6 +73,7 @@ public class GenericInvoke {
 
     private static ReferenceConfig<GenericService> addNewReference(String interfaceName,
                                                                    String group, String version) {
+
         ReferenceConfig<GenericService> reference;
         String cachedKey = interfaceName + group + version;
         reference = cachedConfig.get(cachedKey);

--- a/src/main/java/org/apache/dubbo/proxy/worker/RequestWorker.java
+++ b/src/main/java/org/apache/dubbo/proxy/worker/RequestWorker.java
@@ -23,7 +23,7 @@ import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import io.netty.util.CharsetUtil;
 import org.apache.dubbo.metadata.definition.model.FullServiceDefinition;
 import org.apache.dubbo.metadata.definition.model.MethodDefinition;
-import org.apache.dubbo.metadata.identifier.MetadataIdentifier;
+import org.apache.dubbo.metadata.report.identifier.MetadataIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +72,7 @@ public class RequestWorker implements Runnable {
                     serviceDefinition.getMethodName(),
                     serviceDefinition.getParamTypes(), serviceDefinition.getParamValues());
         } catch (Exception e) {
-            e.printStackTrace();
+//            e.printStackTrace();
             result = e;
         }
         if (!writeResponse(ctx, result)) {


### PR DESCRIPTION
dubbo 2.7.3 存在性能瓶颈。
org.apache.dubbo.config.ReferenceConfig#get 方法中，会调用org.apache.dubbo.config.ReferenceConfig#checkAndUpdateSubConfigs 方法，经过测试显示此方法每次调用时会花费较多的时间，不应当在每次调用get方法的时候都去调用此方法，而是应当在init方法中调用一次即可（在对象对创建时调用）。

升级dubbo版本到2.7.7可以解决此问题。